### PR TITLE
 Add About and Data Usage Policies markdown pages (ODS migration)

### DIFF
--- a/aboutData.md
+++ b/aboutData.md
@@ -1,0 +1,26 @@
+---
+title: Childhood Cancer Data Initiative Hub
+About_Img: "https://raw.githubusercontent.com/CBIIT/CCDI_Hub_Assets/main/Image/About/About_Img.png"
+---
+
+The Childhood Cancer Data Initiative (CCDI) Hub is an entry point for researchers, data scientists, and citizen scientists looking to use and connect with CCDI-supported data, tools, and applications.  The CCDI Hub’s mission is to support innovative research through increased accessibility of pediatric cancer research datasets and resources.
+
+It provides information about available tools and applications that support the CCDI vision, along with descriptions of resources, each of which targets specific aspects of childhood cancer research. The Explore Dashboard, an integrated tool of the CCDI Hub, provides participant-centric search functionality by connecting participants with files and samples. The Explore Dashboard enables researchers to find data within a single study or across multiple studies and create synthetic cohorts based on filtered metrics (i.e., demographics, diagnosis, samples, etc.) of interest.
+
+The Hub also provides direct links to resources and additional technical information. Users are invited to explore the Hub or select a resource’s link to learn more.
+
+## Childhood Cancer Data Initiative
+
+The [NCI's Childhood Cancer Data Initiative (CCDI)](https://www.cancer.gov/research/areas/childhood/childhood-cancer-data-initiative) is building a community centered around childhood cancer care and research data. By connecting, analyzing, and easily sharing data among researchers, we can increase our understanding of childhood cancers and improve treatment, quality of life, and survivorship for all children, adolescents, and young adults with cancer.
+
+The NCI is committed to supporting the pediatric cancer research community. We value your input and are here to help you with any questions or feedback regarding the CCDI Hub.
+
+For all inquiries, including questions about the CCDI Hub, its resources, or how to get involved please send an [email to Childhood Cancer Data Initiative](mailto:ncichildhoodcancerdatainitiative@mail.nih.gov).
+
+Our team is dedicated to:
+
+- Answering your questions about the CCDI Hub and its features
+- Providing support for using the CCDI Hub Explore Dashboard.
+- Receiving feedback on how we can improve the CCDI Hub Explore Dashboard: recommendations for additional filtering or search functionalities, suggestions for enhancing the user interface or navigation, feedback on performance or responsiveness of the dashboard, etc.
+
+We look forward to hearing from you and enhancing the CCDI Hub to better serve the pediatric cancer research community.

--- a/dataUsagePolicies.md
+++ b/dataUsagePolicies.md
@@ -1,0 +1,40 @@
+---
+title: Data Usage Policies
+Data_Usage_Policies_Header: "https://raw.githubusercontent.com/CBIIT/CCDI_Hub_Assets/main/Image/About/Data_Usage_Policies_Header.png"
+---
+
+There are policies and terms to keep in mind when using and connecting with Childhood Cancer Data Initiative (CCDI)-managed data and tools through the CCDI Hub.
+
+> If you’re looking for information on how to find, request, access, download, and analyze controlled-access data managed by CCDI, see our [data access instructions guide.](https://datacatalog.ccdi.cancer.gov/CCDI_CGC_Data_Access_Instructions_2.0.pdf)
+
+## Data Use Expectations
+
+The CCDI Hub allows the public to view and analyze cancer data based on the NIH/NCI Data Use Agreements specific to individual data sets. Users agree not to use CCDI data, either alone or with any other information, to identify or contact individual participants from whom data and/or samples were collected. Additionally, users must protect all CCDI data from being inadvertently made identifiable through reverse-engineering algorithms or analytical reidentification techniques.
+
+## Data Disclaimers
+
+Data are exceedingly valuable for our improved understanding of cancer and are the foundation for the discovery of many novel targets or biomarker signatures. When interpreting the data and/or using the information in follow-up experiments, it is the user’s responsibility to determine whether the initial design is suitable for their downstream goals, understand the bases of any errors, and apply appropriate filters.
+
+## CCDI Acknowledgement
+
+NCI recommends users follow standard scientific etiquette and practices when working with CCDI-managed data or publishing results generated using the data.
+
+- Acknowledge in all oral or written presentations, disclosures, or publications the specific data set(s) or applicable Digital Object Identifiers, and the data repositories through which the investigator accessed the data. Citation guidelines for doing this are outlined below.
+- Notify us at [ncichildhoodcancerdatainitiative@mail.nih.gov](mailto:ncichildhoodcancerdatainitiative@mail.nih.gov) if you have utilized CCDI-managed data in your research, so we can include your work on our web pages.
+- Properly reference original research paper(s) if the data being used corresponds to a manuscript(s) resulting from CCDI-supported efforts.
+
+## Citing the CCDI Hub
+
+NCI expects users to acknowledge CCDI data use as follows:
+
+> The results published here are, in whole or in part, derived from the analysis of data listed in the CCDI Hub ([ccdi.cancer.gov](/)), established by the National Cancer Institute’s Childhood Cancer Data Initiative (CCDI).
+
+To cite individual studies, note the CCDI study ID (e.g., phs002790) and include the name and URL or link for the CCDI Hub ([ccdi.cancer.gov](/)), along with the phrase, “established by the National Cancer Institute’s Childhood Cancer Data Initiative (CCDI).”
+
+Example: “The results analyzed and <published or shown> here are based in whole or in part from analyzing the Molecular Characterization Initiative data listed in the CCDI Hub ([ccdi.cancer.gov](/)) under study ID phs002790. The data were accessed from the NCI’s Cancer Research Data Commons ([datacommons.cancer.gov](https://datacommons.cancer.gov/)). The CCDI Hub was established by the National Cancer Institute’s Childhood Cancer Data Initiative (CCDI).”
+
+## Contact
+
+For any questions or concerns related to CCDI-managed data, email CCDI at [ncichildhoodcancerdatainitiative@mail.nih.gov](mailto:ncichildhoodcancerdatainitiative@mail.nih.gov).
+
+> For information on sharing NCI-funded cancer research data, [NCI’s official data sharing policy guidance](https://datascience.cancer.gov/data-sharing/policy-guidance) details the people, policies, requirements, and resources you need to start sharing your data.


### PR DESCRIPTION
Migrate static content from aboutStaticData.yaml into two editor-friendly markdown files, following the same one-page-per-file approach used for mciData.md. This lets non-technical staff update copy without editing HTML or YAML.

aboutData.md (About page)

Map upperTitle, upperText, lowerTitle, lowerText, and aboutText from aboutData Preserve all intro and contact copy, including the Explore Dashboard bullet list Use ## Childhood Cancer Data Initiative for lowerTitle only; aboutText has no YAML display title, so it remains unheaded body content Front matter: title and About_Img URL
dataUsagePolicies.md (Data Usage Policies page)

Map dataUsagePoliciesIntroText and all five dataUsagePoliciesContent sections (Data Use Expectations, Data Disclaimers, CCDI Acknowledgement, Citing the CCDI Hub, Contact) Convert calloutBox paragraphs to blockquotes (>) for plain-markdown editing Convert links to text; citation  blocks to blockquotes/quotes Front matter: title and Data_Usage_Policies_Header URL aboutStaticData.yaml is unchanged for now so the app can switch over after renderer wiring and visual QA. Content was verified against the YAML: no missing sections, no extra invented copy.